### PR TITLE
rename gem to represent loading path

### DIFF
--- a/manageiq-providers-lenovo.gemspec
+++ b/manageiq-providers-lenovo.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 require "manageiq/providers/lenovo/version"
 
 Gem::Specification.new do |s|
-  s.name        = "xclarity"
+  s.name        = "manageiq-providers-lenovo"
   s.version     = ManageIQ::Providers::Lenovo::VERSION
   s.authors     = ["ManageIQ Developers"]
   s.homepage    = "https://github.com/ManageIQ/manageiq"


### PR DESCRIPTION
with the name `xclarity` there has to be a `lib/xclarity.rb` to make the gem load / init.

this naming here follows the miq naming scheme